### PR TITLE
Vectorize modulation mapping and alpha permutation

### DIFF
--- a/BER/get_alpha_perm.m
+++ b/BER/get_alpha_perm.m
@@ -1,23 +1,15 @@
-function B_alpha = get_alpha_perm(n_rows, n_cols, position_array) 
+function B_alpha = get_alpha_perm(n_rows, n_cols, position_array)
 
-B_alpha = zeros([n_rows, n_cols]);
-        
-B_alpha_row = 1;
-for step=1:n_cols-1
-    cont = 1;
-    while cont < n_cols-step+1
-        positive_part = position_array(cont);
-        negative_part = position_array(cont+step);
-        B_alpha(B_alpha_row,positive_part) = 1;
-        B_alpha(B_alpha_row,negative_part) = -1;
+pairs = nchoosek(1:n_cols, 2);
+n_pairs = min(n_rows, size(pairs, 1));
+pairs = pairs(1:n_pairs, :);
 
-        if B_alpha_row == n_rows
-            return;
-        end
+positive = position_array(pairs(:, 1));
+negative = position_array(pairs(:, 2));
 
-        B_alpha_row = B_alpha_row+1;
-        cont = cont + 1;
+B_alpha = zeros(n_rows, n_cols);
+rows = (1:n_pairs).';
+B_alpha(sub2ind([n_rows, n_cols], rows, positive)) = 1;
+B_alpha(sub2ind([n_rows, n_cols], rows, negative)) = -1;
 
-    end
-end
 end

--- a/BER/get_modulation.m
+++ b/BER/get_modulation.m
@@ -1,23 +1,17 @@
-function x_qpsk = get_modulation(nt,n_bits,bits_symbol,constelation_points,gray_code_data,x)
+function x_qpsk = get_modulation(nt, n_bits, bits_symbol, constelation_points, gray_code_data, x)
 
-x_qpsk = zeros([nt, n_bits/bits_symbol]);
+n_symbols = n_bits / bits_symbol;
 
-for row=1:nt
-    col = 1;
-    for counter=1:bits_symbol:n_bits
-        for counter2=1:length(constelation_points)
-            
-            b1 = x(row,counter);
-            b2 = x(row,counter+1);
-            symbol = [b1,b2];
-            
-            if hamming_distance(symbol,gray_code_data(counter2,:))==0
-                x_qpsk(row,col) = constelation_points(counter2);
-                col = col + 1;
-            end
-            
-        end
-    end
-end
+% Map Gray-coded bit patterns to constellation indices
+gray_decimal = bi2de(gray_code_data, 'left-msb');
+map = zeros(1, length(constelation_points));
+map(gray_decimal + 1) = 1:length(constelation_points);
+
+% Group bits into symbols and convert to indices
+bit_pairs = reshape(x.', bits_symbol, []).';
+idx = bi2de(bit_pairs, 'left-msb');
+idx_matrix = reshape(idx, n_symbols, nt).';
+
+x_qpsk = constelation_points(map(idx_matrix + 1));
 
 end


### PR DESCRIPTION
## Summary
- Replace per-symbol search in `get_modulation` with `bi2de` indexing of constellation points.
- Compute comparator rows in `get_alpha_perm` via `nchoosek` and vectorized assignment.

## Testing
- `octave -qf --eval "nt=2;..."` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures unavailable)*


------
https://chatgpt.com/codex/tasks/task_b_68a8bcdd5d34833085170732f3ddd36b