### PR TITLE
Remove duplicate variance calculation in BER.m

### DIFF
--- a/BER/BER.m
+++ b/BER/BER.m
@@ -60,17 +60,6 @@ for h = 1:channel_realizations
     B_alpha_f = 1 / sqrt(2) * get_alpha_perm(full, 2 * Nr, position);
     B_full = [I_Nr_r; B_alpha_f];
     %%%%%%%%%%%%%%%%%%%%%%%%%%
-    %%%%% Variance of H_r approach%%%%%
-    new_H_r = abs(H_r).^2;
-    var_H_r = sum(new_H_r,2);
-    [var_H_r_sort,position] = sort(var_H_r,'descend');
-    [var_H_r_sort_2,position_2] = sort(var_H_r,'ascend');
-    %%%%%
-   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    % Comparator Network Matrices
-    B_prime = 1/sqrt(2) * get_random_perm(alpha,2*Nr);
-    B = [I_Nr_r ; B_prime];
-    %%%%%%%
     B_all_indexes = get_all_perm(n_max_comb , 2*Nr);
     B_all = get_total_perm(2*Nr);
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
## Summary
- Remove redundant block recalculating `new_H_r` and `var_H_r` in BER.m
- Ensure comparator network reuses first computation results

## Testing
- `octave -qf BER/BER.m` *(command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_b_68a8bd2e4330833091439c15fe2face5