### PR TITLE
Cache permutation matrices for reuse

### DIFF
--- a/BER/BER.m
+++ b/BER/BER.m
@@ -19,6 +19,16 @@ alpha_mse=2*Nr;
 %
 n_max_comb = sum(1:2 * Nr - 1);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Precompute comparator permutations and reuse them across iterations
+perm_file = 'perm_matrices.mat';
+if exist(perm_file, 'file')
+    load(perm_file, 'B_all_indexes', 'B_all');
+else
+    B_all_indexes = get_all_perm(n_max_comb, 2 * Nr);
+    B_all = get_total_perm(2 * Nr);
+    save(perm_file, 'B_all_indexes', 'B_all');
+end
+
 % Bits y Modulación
 n_bits = 100; % Número de bits por usuario
 bits_symbol = 2; % Bits por símbolo
@@ -71,8 +81,7 @@ for h = 1:channel_realizations
     B_prime = 1/sqrt(2) * get_random_perm(alpha,2*Nr);
     B = [I_Nr_r ; B_prime];
     %%%%%%%
-    B_all_indexes = get_all_perm(n_max_comb , 2*Nr);
-    B_all = get_total_perm(2*Nr);
+    % B_all_indexes and B_all are precomputed outside the loop
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     M_prime_full = 2 * Nr + full;
     B_alpha_f = 1/sqrt(2) * get_alpha_perm(full,2*Nr,position);


### PR DESCRIPTION
## Summary
- Precompute comparator permutation matrices once per simulation and cache them to `perm_matrices.mat` for reuse.
- Remove redundant generation of permutations inside channel loop.

## Testing
- ⚠️ `octave -qf --eval "addpath('.'); n_max_comb = sum(1:2*4 - 1); perm_file='perm_matrices.mat'; if exist(perm_file,'file'); delete(perm_file); end; if exist(perm_file,'file'); disp('loading'); load(perm_file,'B_all_indexes','B_all'); else; disp('computing'); B_all_indexes=get_all_perm(n_max_comb,8); B_all=get_total_perm(8); save(perm_file,'B_all_indexes','B_all'); end; disp(size(B_all));"` (command not found)
- ⚠️ `apt-get update` (403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_b_68a8bd38636483309aa08df30713ba30