### PR TITLE
Limit get_all_perm to requested combinations

### DIFF
--- a/get_all_perm.m
+++ b/get_all_perm.m
@@ -1,26 +1,35 @@
-function m_comb = get_all_perm(n_max_comb, cols)
-%GET_ALL_PERM Generate all unique pair combinations
-%   m_comb = GET_ALL_PERM(cols) returns all unique combinations
-%   of two indices from 1 to cols.
-%   m_comb = GET_ALL_PERM(n_max_comb, cols) returns up to n_max_comb
-%   unique combinations of two indices from 1 to cols.
 
-% Handle single-argument call by treating it as cols
+function m_comb = get_all_perm(n_max_comb, cols)
+%GET_ALL_PERM Generate up to the first N unique pair combinations
+%   m_comb = GET_ALL_PERM(cols) returns all unique combinations of two
+%   indices from 1 to cols.
+%   m_comb = GET_ALL_PERM(n_max_comb, cols) returns only the first
+%   n_max_comb unique combinations of two indices from 1 to cols.
+
+% Allow calling with a single argument that specifies only the number of
+% columns. In that case, generate all possible combinations.
 if nargin == 1
     cols = n_max_comb;
-    n_max_comb = [];
+    n_max_comb = cols * (cols - 1) / 2;
 end
 
-% Generate all combinations of two indices without explicit loops
-m_comb = nchoosek(1:cols, 2);
+% Total number of unique pairs and validation of the requested amount
+total = cols * (cols - 1) / 2;
+if n_max_comb > total
+    error('n_max_comb exceeds the total number of combinations (%d).', total);
+end
 
-% Truncate if a maximum number of combinations is specified
-if nargin == 2
-    total_combs = size(m_comb, 1);
-    if n_max_comb < total_combs
-        m_comb = m_comb(1:n_max_comb, :);
-    elseif n_max_comb > total_combs
-        warning('n_max_comb exceeds the total number of combinations (%d). Returning all combinations.', total_combs);
+% Preallocate and fill the combinations using nested loops
+m_comb = zeros(n_max_comb, 2);
+row = 1;
+for a = 1:cols-1
+    for b = a + 1:cols
+        m_comb(row, :) = [a, b];
+        row = row + 1;
+        if row > n_max_comb
+            return; % Stop once the desired number of combinations is reached
+        end
     end
 end
+
 end


### PR DESCRIPTION
## Summary
- Generate only the first `n_max_comb` pair combinations
- Validate requested combinations against total and stop loops early

## Testing
- `octave -q --eval "get_all_perm(3,4)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8fe5d75e8833099e8d1da5d07ef44